### PR TITLE
Explictly define imports/exports of $Component.js

### DIFF
--- a/src/$ColorBox.js
+++ b/src/$ColorBox.js
@@ -32,7 +32,7 @@ function $Swatch(color){
 	return $b;
 }
 
-function $ColorBox(){
+function $ColorBox($top, $bottom, $left, $right){
 	var $cb = $(E("div")).addClass("color-box");
 	
 	var $current_colors = $Swatch().addClass("current-colors");
@@ -153,7 +153,7 @@ function $ColorBox(){
 	};
 	build_palette();
 	
-	var $c = $Component("Colors", "wide", $cb);
+	var $c = $Component("Colors", "wide", $cb, $top, $bottom, $left, $right);
 	
 	$c.edit_last_color = function(){
 		// Edit the last color cell that's been selected as the foreground color.

--- a/src/$Component.js
+++ b/src/$Component.js
@@ -1,5 +1,15 @@
+(function({
+	// lib/jquery.min.js
+	$,
+	// src/create-element.js
+	E,
+	// src/$Window.js
+	$Window,
+	// src/helpers.js
+	$G
+}, exports) {
 
-function $Component(name, orientation, $el){
+function $Component(name, orientation, $el, $top, $bottom, $left, $right){
 	// A draggable widget that can be undocked into a window
 	var $c = $(E("div")).addClass("component");
 	$c.addClass(""+name+"-component");
@@ -207,3 +217,7 @@ function $Component(name, orientation, $el){
 	
 	return $c;
 }
+
+exports.$Component = $Component;
+
+})(window, window);

--- a/src/$ToolBox.js
+++ b/src/$ToolBox.js
@@ -1,5 +1,5 @@
 
-function $ToolBox(){
+function $ToolBox($top, $bottom, $left, $right){
 	var $tb = $(E("div")).addClass("tool-box");
 	var $tools = $(E("div")).addClass("tools");
 	var $tool_options = $(E("div")).addClass("tool-options");
@@ -62,7 +62,7 @@ function $ToolBox(){
 		return $b[0];
 	}));
 	
-	var $c = $Component("Tools", "tall", $tools.add($tool_options));
+	var $c = $Component("Tools", "tall", $tools.add($tool_options), $top, $bottom, $left, $right);
 	$c.update_selected_tool = function(){
 		$buttons.removeClass("selected");
 		selected_tool.$button.addClass("selected");

--- a/src/app.js
+++ b/src/app.js
@@ -84,8 +84,8 @@ $status_text.default = function(){
 };
 $status_text.default();
 
-var $toolbox = $ToolBox();
-var $colorbox = $ColorBox();
+var $toolbox = $ToolBox($top, $bottom, $left, $right);
+var $colorbox = $ColorBox($top, $bottom, $left, $right);
 
 if(window.file_entry){
 	open_from_FileEntry(window.file_entry);


### PR DESCRIPTION
- Make `$left`, `$right`, `$top` and `$bottom` explicit parameters to `$Component` and its callers

Closes #9.